### PR TITLE
Debugiterative

### DIFF
--- a/distance.py
+++ b/distance.py
@@ -451,6 +451,10 @@ def mergingCachedBufferStage1(L):
         edwt,pair = minqueue.pop() #visit one voxel each time
         v1,v2 = pair[0],pair[1] #unpack supervoxel
         #Repeat Stage 1 merging, now replace unvisited turbo with new grown units
+        if (v1.label ==4380 or v1.label==4689 or v1.label==4614 or v1.label==4870) and kk==1:
+            print("possible error")
+
+
         if minqueue.size() == 0:
             kk += 1  #flag to count
             # Group the rest/unvisited supervoxels based on largest SA among its nbrs.//smallest orientation
@@ -459,6 +463,8 @@ def mergingCachedBufferStage1(L):
                 maxct = 0
                 maxNbr = None
                 for nbr in L[vid].getAdjList():  # Here we can either uses smallest edge weight, or PriorityQueue()
+                    if nbr.label == 4380:
+                        print('possible error')
                     bdpixels = L[vid].boundary.intersection(nbr.boundary)
                     maxct = max(maxct, len(bdpixels))
                     if maxct == len(bdpixels):
@@ -471,7 +477,7 @@ def mergingCachedBufferStage1(L):
 
             print(f'{voxelchanged} voxels have changed at: {kk}, below is unvisited:')
             print([vid for vid in visited.keys() if not visited[vid]])
-            Supervoxel.writeIntermediateV(uniqueIds, f'analysis/newAllvisit{kk}.tif')
+            #Supervoxel.writeIntermediateV(uniqueIds, f'analysis/newAllvisit{kk}.tif')
 
             if kk==2: break
             #Push to minqueue:
@@ -481,6 +487,9 @@ def mergingCachedBufferStage1(L):
                     if (vid > nbr.id): continue
                     bdpixels = L[vid].boundary.intersection(nbr.boundary)
                     if len(bdpixels) < SAthres: continue
+                    if (L[vid].label == 4380 and nbr.label == 4689) or nbr.label==4380:
+                        print("possible errors")
+
                     edwt = boundaryIntensity(bdpixels, Supervoxel.featuremap)
                     minqueue.push(edwt, frozenset((L[vid].mother, nbr)))
                 visited[L[vid].label] = False
@@ -523,6 +532,7 @@ def mergingCachedBufferStage1(L):
 #To improve:
 #ADD A SURFACE NORMAL METHOD WHICH TAKES 2 SUPERVOXELS DIRECTLY!
 #Use saved staged1 tiff as a starting point, speeding things up!
+#Cached buffer can be used for check unvisited turbovoxels at a stage
 def mergingCachedBufferStage2(uniqueIds, L):
     visited = dict()
     minqueue = PrioritySet()
@@ -539,7 +549,7 @@ def mergingCachedBufferStage2(uniqueIds, L):
             edwt = boundaryIntensity(bdpixels,Supervoxel.featuremap)
 
             # if normwt > 0.3: continue
-            if edwt > 0.5: continue
+            if edwt > 0.6: continue
             if len(bdpixels) < 300: continue
 
             minqueue.push(edwt,frozenset((L[vid].mother,nbr)))
@@ -571,7 +581,7 @@ def mergingCachedBufferStage2(uniqueIds, L):
             if visited[nbr.id] or visited[nbr.label]: continue
             bdpixels = newvoxel.boundary.intersection(nbr.boundary)
             #check surface area
-            if len(bdpixels) < 400: continue
+            if len(bdpixels) < 600: continue
             #check edgeweight constraint
             edwt = boundaryIntensity(bdpixels,Supervoxel.featuremap)
             if edwt > 0.55: continue
@@ -579,6 +589,7 @@ def mergingCachedBufferStage2(uniqueIds, L):
         voxelchange += 1
 
     print(voxelchange)
+    print([k for k,v in visited.items() if not v])
 
 
 def merging(L, iter, threshold, intermediate=False):
@@ -853,7 +864,7 @@ if __name__ == "__main__":
         print("Starts Merging...")
         #priorityQueueMerge(SupervoxelList,totalstep=600)
         uniqueids = mergingCachedBufferStage1(SupervoxelList)
-        mergingCachedBufferStage2(uniqueids, SupervoxelList)
+       # mergingCachedBufferStage2(uniqueids, SupervoxelList)
         Supervoxel.writeAll(fna=f'./analysis/stage2.tif') #or only visied: ([k for k,v in visited.items() if v])
         # writelabel(volume,[322,118,333,397,399,416])  writelabel(volume, 322)
 

--- a/distance.py
+++ b/distance.py
@@ -421,7 +421,7 @@ def mergingCachedBufferStage1(L):
     :return:
     '''
 
-    SAthres = 50
+    SAthres = 60
     visited = collections.defaultdict(bool) #false default
     for k in L:
         visited[k] = False
@@ -435,6 +435,7 @@ def mergingCachedBufferStage1(L):
             bdpixels = L[vid].boundary.intersection(nbr.boundary)
             if len(bdpixels) < SAthres: continue
             edwt = boundaryIntensity(bdpixels, Supervoxel.featuremap)
+            if edwt>0.5: continue
             minqueue.push(edwt,frozenset((L[vid],nbr)))
 
     #Parameters for tuning:
@@ -451,6 +452,10 @@ def mergingCachedBufferStage1(L):
         edwt,pair = minqueue.pop() #visit one voxel each time
         v1,v2 = pair[0],pair[1] #unpack supervoxel
         #Repeat Stage 1 merging, now replace unvisited turbo with new grown units
+        if kk==1:
+            if (v1.label == 3242 and v2.label == 3922) or (v1.label == 3922 and v2.label == 3242):
+                print('error ')
+
 
         if minqueue.size() == 0:
             kk += 1  #flag to count
@@ -461,8 +466,6 @@ def mergingCachedBufferStage1(L):
                 maxct = 0
                 maxNbr = None
                 for nbr in L[vid].getAdjList():  # Here we can either uses smallest edge weight, or PriorityQueue()
-                    # if (nbr.label == 4380 and vid == 4614) or (nbr.label == 4614 and vid == 4380) :
-                    #     print('possible error')
                     bdpixels = L[vid].boundary.intersection(nbr.boundary)
                     edwt = boundaryIntensity(bdpixels,Supervoxel.featuremap)
                     if edwt>0.5: continue
@@ -487,10 +490,8 @@ def mergingCachedBufferStage1(L):
                     if (vid > nbr.id): continue
                     bdpixels = L[vid].boundary.intersection(nbr.boundary)
                     if len(bdpixels) < SAthres: continue
-                    if (L[vid].label == 4614 and nbr.label == 4380) or nbr.label==4380:
-                        print("possible errors")
-
                     edwt = boundaryIntensity(bdpixels, Supervoxel.featuremap)
+                    if edwt>0.4: continue
                     minqueue.push(edwt, frozenset((L[vid].mother, nbr)))
                 visited[L[vid].label] = False
             uniqueIds = set([])
@@ -510,13 +511,13 @@ def mergingCachedBufferStage1(L):
         newvoxel = Supervoxel.allvoxels[v1.label]
         uniqueIds.add(v1.label)
 
-        #Add candiadtes to buffer
-        for nbr in newvoxel.getAdjList():
-            #if visited[nbr.id] or visited[nbr.label]: continue
-            bdpixels = newvoxel.boundary.intersection(nbr.boundary)
-            #if len(bdpixels) < SAthres: continue
-            edwt = boundaryIntensity(bdpixels, Supervoxel.featuremap)
-            #buffer.push(edwt,frozenset((newvoxel,nbr)))
+        # #Add candiadtes to buffer
+        # for nbr in newvoxel.getAdjList():
+        #     #if visited[nbr.id] or visited[nbr.label]: continue
+        #     bdpixels = newvoxel.boundary.intersection(nbr.boundary)
+        #     #if len(bdpixels) < SAthres: continue
+        #     edwt = boundaryIntensity(bdpixels, Supervoxel.featuremap)
+        #     #buffer.push(edwt,frozenset((newvoxel,nbr)))
 
 
         # if buffer.size()%bsz==0 or voxelchanged==100:


### PR DESCRIPTION
STAGE 1 (stricter threshold) - conservative local iterative merging, voxel is only growing in size of 2. (i.e. 2,..4,.. ). At this stage we should be more conservative, as any false merge will lead to errors in STAGE 2. -> perfers oversegments
STAGE 2 (less strict) - merging with no restriction, voxel keeps growing until it reaches threshold. -> could be over/under segments

Observation:
- Threshold matters in merging. **A conservative threshold leads to over-segmentation** and will have unvisited turbovoxels. However it's safer. We should comp up with new strategies to group those *unvisited* voxels
- Orientation metric not performing in a desired way, from my inspection (i.e. 2851, 2514). 
- What stops turbovoxels from growing is the INTENSITY.
- Intensity level 0.4~0.45

